### PR TITLE
DB related fixes

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,6 +2,8 @@
 	"tileSize" : 256,
 	"prefix" : "railmap",
 	"database" : "railmap",
+	"username" : "railmap",
+	"password" : "railmap",
 	"vtiledir" : "/home/www/sites/194.245.35.149/site/orm/tiles",
 	"tiledir" : "/home/www/sites/194.245.35.149/site/orm/bitmap-tiles",
 	"expiredtilesdir" : "/home/www/sites/194.245.35.149/site/olm/import",

--- a/tile.js
+++ b/tile.js
@@ -374,7 +374,7 @@ Tile.prototype =
 		var bbox = this.getBbox();
 		var bbox_p = this.from4326To900913(bbox);
 
-		var connection = "postgres://postgres@localhost/"+configuration.database;
+		var connection = "postgres://"+configuration.username+":"+configuration.password+"@localhost/"+configuration.database;
 		var client = new pg.Client(connection);
 
 		this.debug('Connecting to database '+connection+'...');


### PR DESCRIPTION
After installing node-tileserver on my machine, I ran into two problems. The first was that the code didn't play well with modern PostGIS, which requires the SetSRID function to be prefixed (ST_SetSRID). The second was that the server wanted to connect the DB as user "postgres" which is probably OK for a local deployment, but definitely not good for setting up a public facing server, so I added two config options: "username" and "password" for more flexible Postgres connection. I think that merging these tiny changes will help other users deploying node-tileserver on their machines.
