### PR TITLE
move checks for the zoom level to the front of the expressions

### DIFF
--- a/mapcss_converter.py
+++ b/mapcss_converter.py
@@ -131,7 +131,7 @@ def rule_as_js(self):
     selectors_js = []
     actions_js = []
     for selector in self.selectors:
-        selectors_js.append("(%s%s)" % (selector.as_js(), selector.get_zoom()))
+        selectors_js.append("(%s%s)" % (selector.get_zoom(), selector.as_js()))
 
     for action in self.actions:
         actions_js.append(action.as_js(selector.subpart))
@@ -261,13 +261,13 @@ def selector_get_zoom(self):
     if zoom and zoom[0] == 'z':
         zoom = zoom[1:].split('-')
         if len(zoom) == 1:
-            return ' && zoom === %d' % int(zoom[0])
+            return 'zoom === %d && ' % int(zoom[0])
 
         cond = ''
         if zoom[0]:
-            cond += ' && zoom >= %d' % int(zoom[0])
+            cond += 'zoom >= %d && ' % int(zoom[0])
         if zoom[1]:
-            cond += ' && zoom <= %d' % int(zoom[1])
+            cond += 'zoom <= %d && ' % int(zoom[1])
         return cond
 
     return ''

--- a/tests/basic/zoom/max.pass_re
+++ b/tests/basic/zoom/max.pass_re
@@ -1,1 +1,1 @@
-\(+type == 'way'\)? && \(?zoom <= 15\)+ {.*s_default\['z-index'\] = 1000[^}]*}.*presence_tags = \[[ \t]*\].*value_tags = \[[ \t]*\]
+\(+zoom <= 15\)? && \(?type == 'way'\)+ {.*s_default\['z-index'\] = 1000[^}]*}.*presence_tags = \[\].*value_tags = \[\]

--- a/tests/basic/zoom/min.pass_re
+++ b/tests/basic/zoom/min.pass_re
@@ -1,1 +1,1 @@
-\(+type == 'way'\)? && \(?zoom >= 2\)+ {.*s_default\['z-index'\] = 1000[^}]*}.*presence_tags = \[[ \t]*\].*value_tags = \[[ \t]*\]
+\(+zoom >= 2\)? && \(?type == 'way'\)+ {.*s_default\['z-index'\] = 1000[^}]*}.*presence_tags = \[\].*value_tags = \[\]

--- a/tests/basic/zoom/range.pass_re
+++ b/tests/basic/zoom/range.pass_re
@@ -1,1 +1,1 @@
-\(+type == 'way'\)? && \(?zoom >= 15\)? && \(?zoom <= 17\)+ {.*s_default\['z-index'\] = 1000[^}]*}.*presence_tags = \[[ \t]*\].*value_tags = \[[ \t]*\]
+\(+zoom >= 15\)? && \(?zoom <= 17\)? && \(?type == 'way'\)+ {.*s_default\['z-index'\] = 1000[^}]*}.*presence_tags = \[\].*value_tags = \[\]

--- a/tests/basic/zoom/single.pass_re
+++ b/tests/basic/zoom/single.pass_re
@@ -1,1 +1,1 @@
-\(+type == 'way'\)? && \(?zoom === 15\)+ {.*s_default\['z-index'\] = 1000[^}]*}.*presence_tags = \[[ \t]*\].*value_tags = \[[ \t]*\]
+\(+zoom === 15\)? && \(?type == 'way'\)+ {.*s_default\['z-index'\] = 1000[^}]*}.*presence_tags = \[\].*value_tags = \[\]


### PR DESCRIPTION
This should make rendering at lower zoom levels much more efficient, as there
are many objects per tile and most expressions will probably not match because
of the zoom level. The check for the zoom level is relatively cheap as it is
just comparing two integers, so it avoids more expensive checks like string
equality or regular expression matches when those objects will not be drawn
anyway. On the other hand this makes rendering on lower zoom levels slightly
less efficient.