### PR TITLE
break lines in generated if statements

### DIFF
--- a/mapcss_converter.py
+++ b/mapcss_converter.py
@@ -126,7 +126,7 @@ def rule_as_js(self):
     for action in self.actions:
         actions_js.append(action.as_js(selector.subpart))
 
-    return """\n        if (%s) %s""" % (" || ".join(selectors_js), "".join(actions_js))
+    return """\n        if (%s) %s""" % (" || \n            ".join(selectors_js), "".join(actions_js))
 
 def selector_as_js(self):
     criteria = " && ".join(map(lambda x: x.as_js(), self.criteria))

--- a/mapcss_converter.py
+++ b/mapcss_converter.py
@@ -400,8 +400,10 @@ if __name__ == "__main__":
     presence_tags -= value_tags
 
     js += """
-    var sprite_images = {%s
-    }, external_images = [%s], presence_tags = [%s], value_tags = [%s];
+    var sprite_images = {%s};
+    var external_images = [%s];
+    var presence_tags = [%s];
+    var value_tags = [%s];
 
     MapCSS.loadStyle('%s', restyle, sprite_images, external_images, presence_tags, value_tags);
     MapCSS.preloadExternalImages('%s');


### PR DESCRIPTION
Use a new line for every single match expression in an if, this makes the
generated code much more readable.