### PR TITLE
improve importing of Image library

### DIFF
--- a/mapcss_converter.py
+++ b/mapcss_converter.py
@@ -27,7 +27,7 @@
 import sys
 import os
 import re
-import Image
+from PIL import Image
 
 import cairo
 import tempfile


### PR DESCRIPTION
On some systems (namely the Ubuntu 12.04 based Travis CI) importing just Image
fails. The more verbose version works on all systems tested so far.