### PR TITLE
fix JavaScript functions being added to value_tags map

### DIFF
--- a/mapcss_converter.py
+++ b/mapcss_converter.py
@@ -207,7 +207,8 @@ def style_statement_as_js(self, subpart):
     val = escape_value(self.key, self.value, subpart)
     k = wrap_key(self.key)
     if self.key == 'text':
-        value_tags.add(val)
+        if not isinstance(self.value, ast.Eval):
+            value_tags.add(val)
         return "            s_%s[%s] = MapCSS.e_localize(tags, %s);" % (subpart, k, val)
     else:
         if self.key in ('icon-image', 'fill-image'):
@@ -224,6 +225,11 @@ def eval_as_js(self, subpart):
 def eval_function_as_js(self, subpart):
     args = ", ".join(map(lambda arg: arg.as_js(subpart), self.arguments))
     if self.function == 'tag':
+        # use the correct quotes
+        if args[0:1] == '"' and args[-1:] == '"':
+            value_tags.add("'%s'" % args[1:-1])
+        else:
+            value_tags.add("'%s'" % args)
         return "MapCSS.e_tag(tags, %s)" % (args)
     elif self.function == 'prop':
         return "MapCSS.e_prop(s_%s, %s)" % (subpart, args)

--- a/tests/eval/join.pass_re
+++ b/tests/eval/join.pass_re
@@ -1,1 +1,1 @@
-\(+type == 'way'\)+ {.*s_default\['text'\] = MapCSS\.e_localize\(tags, MapCSS.e_join\(" ", MapCSS\.e_tag\(tags, "bar"\), MapCSS\.e_tag\(tags, "foo"\)\)\).*}.*presence_tags = \[[ \t]*\]
+\(+type == 'way'\)+ {.*s_default\['text'\] = MapCSS\.e_localize\(tags, MapCSS.e_join\(" ", MapCSS\.e_tag\(tags, "bar"\), MapCSS\.e_tag\(tags, "foo"\)\)\).*}.*presence_tags = \[[ \t]*\].*value_tags = \['bar', 'foo'\]

--- a/tests/eval/numeric.pass_re
+++ b/tests/eval/numeric.pass_re
@@ -1,1 +1,1 @@
-\(+type == 'way'\)+ {.*s_default\['z-index'\] = MapCSS.e_tag\(tags, "maxspeed"\) \* 2.*}.*presence_tags = \[[ \t]*\]
+\(+type == 'way'\)+ {.*s_default\['z-index'\] = MapCSS.e_tag\(tags, "maxspeed"\) \* 2.*}.*presence_tags = \[[ \t]*\].*value_tags = \['maxspeed'\]


### PR DESCRIPTION
In case the value of a text element is calculated by a function (e.g. join())
the JavaScript code that did the calculation was added to the value_tags map:

  MapCSS.e_join(" ", MapCSS.e_tag(tags, "razed:ref"), MapCSS.e_tag(tags, "razed:name"))

Check if the expression comes from an eval statement, and simply ignore it in
that case. Instead add the tags to the map when the call to MapCSS.e_tag() is
generated.