### PR TITLE
fix the regular expression for the basic_objects_combined test

### DIFF
--- a/tests/basic/objects_combined.pass_re
+++ b/tests/basic/objects_combined.pass_re
@@ -1,0 +1,1 @@
+\(+type == 'way'\)?[ \t]*||[ \t]*\(?type == 'node'\)?[ \t]*||[ \t]*\(?selector == 'area'\)+ {.*s_default\['z-index'\] = 1000[^}]*}.*presence_tags = \[\].*value_tags = \[\]

--- a/tests/basic/objects_joined.pass_re
+++ b/tests/basic/objects_joined.pass_re
@@ -1,1 +1,0 @@
-\(+type == 'way'\)?[ \t]*||[ \t]*\(?type == 'node'\)?[ \t]*||[ \t]*\(?selector == 'area'\)+ {.*s_default\['z-index'\] = 1000[^}]*}.*presence_tags = \[[ \t]*\].*value_tags = \[[ \t]*\]


### PR DESCRIPTION
The file had the wrong name. While at it remove optional whitespace in the regex that is not there.