### PR TITLE
rework how e_localize() and e_tag() work

### DIFF
--- a/kothic/style/mapcss.js
+++ b/kothic/style/mapcss.js
@@ -85,7 +85,7 @@ var MapCSS = {
 
     e_tag: function (obj, tag) {
         if (obj.hasOwnProperty(tag) && obj[tag] !== null) {
-            return tag;
+            return obj[tag];
         } else {
             return '';
         }
@@ -141,33 +141,18 @@ var MapCSS = {
         return MapCSS.e_metric(arg);
     },
 
-    e_localize: function (tags, text) {
-        var locales = MapCSS.locales, i, j, tag;
-		var tagcombination = text;
-		var keys = tagcombination.split(" ");
+	e_localize: function (tags, text) {
+		var locales = MapCSS.locales, i, tag;
 
-		// replace keys by localized keys if existing
-        for (j = 0; j < keys.length; j++) {
-		    for (i = 0; i < locales.length; i++) {
-		        tag = keys[j] + ':' + locales[i];
-		        if (tags[tag]) {
-					tagcombination = tagcombination.replace(tag, tags[tag]);
-		        }
-		    }
-		}
-
-		// replace keys by values
-        for (j = 0; j < keys.length; j++) {
-			if (tags[keys[j]]) {
-				tagcombination = tagcombination.replace(keys[j], tags[keys[j]]);
-			}
-			else {
-				tagcombination = tagcombination.replace(keys[j], "");
+		for (i = 0; i < locales.length; i++) {
+			tag = text + ':' + locales[i];
+			if (tags[tag]) {
+				return tags[tag];
 			}
 		}
 
-		return tagcombination.trim();
-    },
+		return tags[text] ? tags[text] : "";
+	},
 
 	e_concat: function () {
 		var tagString = "";

--- a/tests/basic/tag-values.pass_re
+++ b/tests/basic/tag-values.pass_re
@@ -1,0 +1,1 @@
+\(+type == 'node'\)+ {.*s_default\['text'\] = MapCSS\.e_localize\(tags, 'name'\)[^}]*}.*presence_tags = \[\].*value_tags = \['name'\]

--- a/tests/basic/tag-values.tst
+++ b/tests/basic/tag-values.tst
@@ -1,0 +1,4 @@
+node
+{
+	text: "name";
+}

--- a/tests/eval/concat.pass_re
+++ b/tests/eval/concat.pass_re
@@ -1,0 +1,1 @@
+\(+type == 'way'\)+ {.*s_default\['text'\] = MapCSS.e_concat\(" ", MapCSS\.e_localize\(tags, "bar"\), MapCSS\.e_localize\(tags, "foo"\)\).*}.*presence_tags = \[\].*value_tags = \[('bar', 'foo'|'foo', 'bar')\]

--- a/tests/eval/concat.tst
+++ b/tests/eval/concat.tst
@@ -1,0 +1,4 @@
+way
+{
+	text: eval(concat(" ", tag("bar"), tag("foo")));
+}

--- a/tests/eval/join.pass_re
+++ b/tests/eval/join.pass_re
@@ -1,1 +1,1 @@
-\(+type == 'way'\)+ {.*s_default\['text'\] = MapCSS\.e_localize\(tags, MapCSS.e_join\(" ", MapCSS\.e_tag\(tags, "bar"\), MapCSS\.e_tag\(tags, "foo"\)\)\).*}.*presence_tags = \[[ \t]*\].*value_tags = \[('bar', 'foo'|'foo', 'bar')\]
+\(+type == 'way'\)+ {.*s_default\['text'\] = MapCSS\.e_join\(" ", MapCSS\.e_localize\(tags, "bar"\), MapCSS\.e_localize\(tags, "foo"\)\).*}.*presence_tags = \[\].*value_tags = \[('bar', 'foo'|'foo', 'bar')\]


### PR DESCRIPTION
Instead of e.g. concatenating the tag names for eval(join()), and then splitting stuff up again, looking up the tags and then adding their values do it the other way round: let e_tag() directly return the value, as otherwise e.g. cond() will not work. Use e_localize() inside the join() so the already localized values will be concatenated. Otherwise one may accidentially replace text with other text if a key with the given text exists.