### PR TITLE
use different operators when comparing with numbers

### DIFF
--- a/mapcss_converter.py
+++ b/mapcss_converter.py
@@ -49,8 +49,22 @@ from mapcss_parser import MapCSSParser
 from mapcss_parser import ast
 
 
-CHECK_OPERATORS = {
+# operators when comparing to numbers
+# do not check for type equality here as the left hand part will come from the tags
+# array and is a string
+CHECK_OPERATORS_NUM = {
     '=': '==',
+    '<': '<',
+    '<=': '<=',
+    '>': '>',
+    '>=': '>=',
+    '!=': '!=',
+    '<>': '!='
+}
+
+# operators when comparing to strings
+CHECK_OPERATORS = {
+    '=': '===',
     '<': '<',
     '<=': '<=',
     '>': '>',
@@ -178,7 +192,7 @@ def condition_check_as_js(self):
     elif self.sign == '~=':
         return "MapCSS.e_tag(tags, '%s').split(';').indexOf('%s') >= 0" % (k, v)
     elif isNumeric(v):
-        return "tags['%s'] %s %s" % (k, CHECK_OPERATORS[self.sign], v)
+        return "tags['%s'] %s %s" % (k, CHECK_OPERATORS_NUM[self.sign], v)
     else:
         return "tags['%s'] %s '%s'" % (k, CHECK_OPERATORS[self.sign], v)
 

--- a/tests/basic/selector/equal.pass_re
+++ b/tests/basic/selector/equal.pass_re
@@ -1,1 +1,1 @@
-\(+type == 'way'\)? && \(?tags\['bridge'\] == 'yes'\)+ {.*s_default\['z-index'\] = 1000[^}]*}.*presence_tags = \[[ \t]*\].*value_tags = \['bridge'\]
+\(+type == 'way'\)? && \(?tags\['bridge'\] === 'yes'\)+ {.*s_default\['z-index'\] = 1000[^}]*}.*presence_tags = \[[ \t]*\].*value_tags = \['bridge'\]

--- a/tests/basic/selector/equal_quoted.pass_re
+++ b/tests/basic/selector/equal_quoted.pass_re
@@ -1,1 +1,1 @@
-\(+type == 'way'\)? && \(?tags\['bridge'\] == 'yes'\)+ {.*s_default\['z-index'\] = 1000[^}]*}.*presence_tags = \[[ \t]*\].*value_tags = \['bridge'\]
+\(+type == 'way'\)? && \(?tags\['bridge'\] === 'yes'\)+ {.*s_default\['z-index'\] = 1000[^}]*}.*presence_tags = \[[ \t]*\].*value_tags = \['bridge'\]

--- a/tests/basic/selector/unequal.pass_re
+++ b/tests/basic/selector/unequal.pass_re
@@ -1,0 +1,1 @@
+\(+type == 'way'\)? && \(?tags\['bridge'\] !== 'yes'\)+ {.*s_default\['z-index'\] = 1000[^}]*}.*presence_tags = \[[ \t]*\].*value_tags = \['bridge'\]

--- a/tests/basic/selector/unequal.tst
+++ b/tests/basic/selector/unequal.tst
@@ -1,0 +1,4 @@
+way[bridge!=yes]
+{
+	z-index: 1000;
+}

--- a/tests/basic/selector/unequal_numeric.pass_re
+++ b/tests/basic/selector/unequal_numeric.pass_re
@@ -1,0 +1,1 @@
+\(+type == 'way'\)? && \(?tags\['maxspeed'\] != 80\)+ {.*s_default\['z-index'\] = 1000[^}]*}.*presence_tags = \[[ \t]*\].*value_tags = \['maxspeed'\]

--- a/tests/basic/selector/unequal_numeric.tst
+++ b/tests/basic/selector/unequal_numeric.tst
@@ -1,0 +1,4 @@
+way[maxspeed!=80]
+{
+	z-index: 1000;
+}

--- a/tests/basic/selector/unequal_quoted.pass_re
+++ b/tests/basic/selector/unequal_quoted.pass_re
@@ -1,0 +1,1 @@
+\(+type == 'way'\)? && \(?tags\['bridge'\] !== 'yes'\)+ {.*s_default\['z-index'\] = 1000[^}]*}.*presence_tags = \[[ \t]*\].*value_tags = \['bridge'\]

--- a/tests/basic/selector/unequal_quoted.tst
+++ b/tests/basic/selector/unequal_quoted.tst
@@ -1,0 +1,4 @@
+way["bridge"!="yes"]
+{
+	z-index: 1000;
+}


### PR DESCRIPTION
When checking a value against a number in case of equality currently the operator '==' was used (equality without type checking), but in case of inequality the operator '!==' was used (inequality with type checking). Since the value checked was always a string and the other value was a number the type was never the same and the inequality operator always returned true.

From now on the type equality is never used when comparing to a number, thus making it basically work as expected. When comparing other types (i.e. strings on both sides) always check for type equality to avoid any conversions from happening.