### PR TITLE
fix "@import" statements

### DIFF
--- a/mapcss_converter.py
+++ b/mapcss_converter.py
@@ -126,7 +126,7 @@ def escape_value(key, value, subpart):
         return "'%s'" % value
 
 def mapcss_as_aj(self):
-    imports = "".join(map(lambda imp: propagate_import(imp.url).as_js, self.imports))
+    imports = "".join(map(lambda imp: propagate_import(imp.url).as_js(), self.imports))
     rules = "".join(map(lambda x: x.as_js(), self.rules))
     return "%s%s" % (imports, rules)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,3 +37,5 @@ foreach(_file IN LISTS TEST_FILES)
 	add_test(NAME "bug_${_name}" COMMAND ${_converter_command} -o - -i "${CMAKE_CURRENT_SOURCE_DIR}/${_file}")
 	set_tests_properties(bug_${_name} PROPERTIES PASS_REGULAR_EXPRESSION "Illegal character '.' at line")
 endforeach ()
+
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/import.css" "${CMAKE_CURRENT_BINARY_DIR}/import.css" COPYONLY)

--- a/tests/import.css
+++ b/tests/import.css
@@ -1,0 +1,1 @@
+way { z-index: 42 }

--- a/tests/import/basic.pass_re
+++ b/tests/import/basic.pass_re
@@ -1,0 +1,1 @@
+\(+type == 'way'\)+ {.*s_default\['z-index'\] = 42[^}]*}.*presence_tags = \[\].*value_tags = \[\]

--- a/tests/import/basic.tst
+++ b/tests/import/basic.tst
@@ -1,0 +1,1 @@
+@import url("import.css");

--- a/tests/import/pseudoclass.pass_re
+++ b/tests/import/pseudoclass.pass_re
@@ -1,0 +1,1 @@
+\(+type == 'way'\)+ {.*s_default\['z-index'\] = 42[^}]*}.*presence_tags = \[\].*value_tags = \[\]

--- a/tests/import/pseudoclass.tst
+++ b/tests/import/pseudoclass.tst
@@ -1,0 +1,1 @@
+@import url("import.css") foo;


### PR DESCRIPTION
Otherwise it would fail with errors like this:

  File "node-tileserver/tests/../mapcss_converter.py", line 144, in mapcss_as_aj
   imports = "".join(map(lambda imp: propagate_import(imp.url).as_js, self.imports))