### PR TITLE
Fix rendering errors

### DIFF
--- a/kothic/renderer/path.js
+++ b/kothic/renderer/path.js
@@ -89,12 +89,12 @@ Kothic.path = (function () {
         var type = feature.type,
             coords = feature.coordinates;
 
-        if (type === "Polygon") {
-            coords = [coords];
-            type = "MultiPolygon";
-        } else if (type === "LineString") {
+        if (type === "LineString") {
             coords = [coords];
             type = "MultiLineString";
+        } else if (type === "Polygon") {
+            coords = [coords];
+            type = "MultiPolygon";
         }
 
         var i, j, k,
@@ -104,31 +104,7 @@ Kothic.path = (function () {
             prevPoint, point, screenPoint,
             dx, dy, dist;
 
-        if (type === "MultiPolygon") {
-            for (i = 0; i < len; i++) {
-                for (k = 0, len2 = coords[i].length; k < len2; k++) {
-                    points = coords[i][k];
-                    pointsLen = points.length;
-                    prevPoint = points[0];
-
-                    for (j = 0; j <= pointsLen; j++) {
-                        point = points[j] || points[0];
-                        screenPoint = Kothic.geom.transformPoint(point, ws, hs);
-
-                        if (j === 0 || (!fill &&
-                                isTileBoundary(point, granularity) &&
-                                isTileBoundary(prevPoint, granularity))) {
-                            moveTo(ctx, screenPoint, dashes);
-                        } else if (fill || !dashes) {
-                            ctx.lineTo(screenPoint[0], screenPoint[1]);
-                        } else {
-                            dashTo(ctx, screenPoint);
-                        }
-                        prevPoint = point;
-                    }
-                }
-            }
-        } else if (type === "MultiLineString") {
+        if (type === "MultiLineString") {
             var pad = 50, // how many pixels to draw out of the tile to avoid path edges when lines crosses tile borders
                 skip = 2; // do not draw line segments shorter than this
 
@@ -170,6 +146,30 @@ Kothic.path = (function () {
                         dashTo(ctx, screenPoint);
                     } else {
                         ctx.lineTo(screenPoint[0], screenPoint[1]);
+                    }
+                }
+            }
+        } else if (type === "MultiPolygon") {
+            for (i = 0; i < len; i++) {
+                for (k = 0, len2 = coords[i].length; k < len2; k++) {
+                    points = coords[i][k];
+                    pointsLen = points.length;
+                    prevPoint = points[0];
+
+                    for (j = 0; j <= pointsLen; j++) {
+                        point = points[j] || points[0];
+                        screenPoint = Kothic.geom.transformPoint(point, ws, hs);
+
+                        if (j === 0 || (!fill &&
+                                isTileBoundary(point, granularity) &&
+                                isTileBoundary(prevPoint, granularity))) {
+                            moveTo(ctx, screenPoint, dashes);
+                        } else if (fill || !dashes) {
+                            ctx.lineTo(screenPoint[0], screenPoint[1]);
+                        } else {
+                            dashTo(ctx, screenPoint);
+                        }
+                        prevPoint = point;
                     }
                 }
             }

--- a/kothic/renderer/path.js
+++ b/kothic/renderer/path.js
@@ -92,9 +92,7 @@ Kothic.path = (function () {
         if (type === "Polygon") {
             coords = [coords];
             type = "MultiPolygon";
-        }
-
-        if (type === "LineString") {
+        } else if (type === "LineString") {
             coords = [coords];
             type = "MultiLineString";
         }
@@ -104,9 +102,7 @@ Kothic.path = (function () {
             len = coords.length,
             len2, pointsLen,
             prevPoint, point, screenPoint,
-            dx, dy, dist,
-            pad = 50, // how many pixels to draw out of the tile to avoid path edges when lines crosses tile borders
-            skip = 2; // do not draw line segments shorter than this
+            dx, dy, dist;
 
         if (type === "MultiPolygon") {
             for (i = 0; i < len; i++) {
@@ -132,9 +128,10 @@ Kothic.path = (function () {
                     }
                 }
             }
-        }
+        } else if (type === "MultiLineString") {
+            var pad = 50, // how many pixels to draw out of the tile to avoid path edges when lines crosses tile borders
+                skip = 2; // do not draw line segments shorter than this
 
-        if (type === "MultiLineString") {
             for (i = 0; i < len; i++) {
                 points = coords[i];
                 pointsLen = points.length;

--- a/kothic/renderer/path.js
+++ b/kothic/renderer/path.js
@@ -104,7 +104,9 @@ Kothic.path = (function () {
             len = coords.length,
             len2, pointsLen,
             prevPoint, point, screenPoint,
-            dx, dy, dist, pad = 50;
+            dx, dy, dist,
+            pad = 50, // how many pixels to draw out of the tile to avoid path edges when lines crosses tile borders
+            skip = 2; // do not draw line segments shorter than this
 
         if (type === "MultiPolygon") {
             for (i = 0; i < len; i++) {
@@ -143,11 +145,23 @@ Kothic.path = (function () {
 
                     // continue path off the tile by some abount to fix path edges between tiles
                     if ((j === 0 || j === pointsLen - 1) && isTileBoundary(point, granularity)) {
-                        prevPoint = points[j ? pointsLen - 2 : 1];
+                        k = j;
+                        do {
+                            k = j ? k - 1 : k + 1;
+                            if (k < 0 || k >= pointsLen)
+                                break;
+                            prevPoint = points[k];
 
-                        dx = point[0] - prevPoint[0];
-                        dy = point[1] - prevPoint[1];
-                        dist = Math.sqrt(dx * dx + dy * dy);
+                            dx = point[0] - prevPoint[0];
+                            dy = point[1] - prevPoint[1];
+                            dist = Math.sqrt(dx * dx + dy * dy);
+                        } while (dist <= skip);
+
+                        // all points are so close to each other that it doesn't make sense to
+                        // draw the line beyond the tile border, simply skip the entire line from
+                        // here
+                        if (k < 0 || k >= pointsLen)
+                            break;
 
                         screenPoint[0] = screenPoint[0] + pad * dx / dist;
                         screenPoint[1] = screenPoint[1] + pad * dy / dist;

--- a/kothic/renderer/path.js
+++ b/kothic/renderer/path.js
@@ -141,7 +141,6 @@ Kothic.path = (function () {
 
                 for (j = 0; j < pointsLen; j++) {
                     point = points[j];
-                    screenPoint = Kothic.geom.transformPoint(point, ws, hs);
 
                     // continue path off the tile by some abount to fix path edges between tiles
                     if ((j === 0 || j === pointsLen - 1) && isTileBoundary(point, granularity)) {
@@ -163,9 +162,10 @@ Kothic.path = (function () {
                         if (k < 0 || k >= pointsLen)
                             break;
 
-                        screenPoint[0] = screenPoint[0] + pad * dx / dist;
-                        screenPoint[1] = screenPoint[1] + pad * dy / dist;
+                        point[0] = point[0] + pad * dx / dist;
+                        point[1] = point[1] + pad * dy / dist;
                     }
+                    screenPoint = Kothic.geom.transformPoint(point, ws, hs);
 
                     if (j === 0) {
                         moveTo(ctx, screenPoint, dashes);


### PR DESCRIPTION
This should fix all known instances of the "ghost lines" (#11). While at it it slightly reorders the rendering code, which should avoid some useless instruction during rendering.