### PR TITLE
Rework font property handling

### DIFF
--- a/kothic/renderer/shields.js
+++ b/kothic/renderer/shields.js
@@ -44,7 +44,7 @@ Kothic.shields = {
         }
 
         Kothic.style.setStyles(ctx, {
-            font: Kothic.style.getFontString(style["shield-font-family"] || style["font-family"], style["shield-font-size"] || style["font-size"]),
+            font: Kothic.style.getFontString(style["shield-font-family"] || style["font-family"], style["shield-font-size"] || style["font-size"], style),
             fillStyle: style["shield-text-color"] || "#000000",
             globalAlpha: style["shield-text-opacity"] || style.opacity || 1,
             textAlign: 'center',

--- a/kothic/renderer/texticons.js
+++ b/kothic/renderer/texticons.js
@@ -65,7 +65,7 @@ Kothic.texticons = {
         if (renderText) {
             Kothic.style.setStyles(ctx, {
                 lineWidth: style['text-halo-radius'] * 2,
-                font: Kothic.style.getFontString(style['font-family'], style['font-size'])
+                font: Kothic.style.getFontString(style['font-family'], style['font-size'], style)
             });
 
             var text = String(style.text),

--- a/kothic/style/style.js
+++ b/kothic/style/style.js
@@ -127,7 +127,7 @@ Kothic.style = {
 
         styles.push(size + 'px');
 
-        if (name.indexOf('serif') !== -1) {
+        if (name.indexOf('serif') !== -1 && name.indexOf('sans-serif') === -1) {
             family += 'Georgia, serif';
         } else {
             family += '"Helvetica Neue", Arial, Helvetica, sans-serif';

--- a/kothic/style/style.js
+++ b/kothic/style/style.js
@@ -115,15 +115,14 @@ Kothic.style = {
         name = name.toLowerCase();
 
         var styles = [];
-        if (st['font-style'] == 'italic' || name.indexOf('italic') !== -1 || name.indexOf('oblique') !== -1) {
+        if (st['font-style'] == 'italic') {
             styles.push('italic');
         }
         if (st['font-variant'] == 'small-caps') {
             styles.push('small-caps');
         }
-        if (st['font-weight'] == 'bold' || name.indexOf('bold') !== -1) {
+        if (st['font-weight'] == 'bold') {
             styles.push('bold');
-            family += name.replace('bold', '') + ', ';
         }
 
         styles.push(size + 'px');

--- a/kothic/style/style.js
+++ b/kothic/style/style.js
@@ -106,7 +106,7 @@ Kothic.style = {
         return styledFeatures;
     },
 
-    getFontString: function (name, size) {
+    getFontString: function (name, size, st) {
         name = name || '';
         size = size || 9;
 
@@ -115,12 +115,14 @@ Kothic.style = {
         name = name.toLowerCase();
 
         var styles = [];
-        if (name.indexOf('italic') !== -1 || name.indexOf('oblique') !== -1) {
+        if (st['font-style'] == 'italic' || name.indexOf('italic') !== -1 || name.indexOf('oblique') !== -1) {
             styles.push('italic');
         }
-        if (name.indexOf('bold') !== -1) {
+        if (st['font-variant'] == 'small-caps') {
+            styles.push('small-caps');
+        }
+        if (st['font-weight'] == 'bold' || name.indexOf('bold') !== -1) {
             styles.push('bold');
-            //family += '''+name.replace('bold', '')+'', ';
             family += name.replace('bold', '') + ', ';
         }
 
@@ -132,7 +134,6 @@ Kothic.style = {
             family += '"Helvetica Neue", Arial, Helvetica, sans-serif';
         }
         styles.push(family);
-
 
         return styles.join(' ');
     },


### PR DESCRIPTION
This adds support for the font-weight, font-style, and font-variant properties. It further removes some heuristics of the old code that were used to make bold and italic fonts at least sometimes work with the old code.

What does not work anymore is that only setting a font family to something that has "bold" in the name but not specifying "font-weight: bold", which has been fixed in [#420 in OpenRailwayMap](https://github.com/rurseekatze/OpenRailwayMap/pull/420).

This fixes #16 and #75.