### PR TITLE
allow square brackets in regular expressions

### DIFF
--- a/mapcss_parser/lex.py
+++ b/mapcss_parser/lex.py
@@ -43,6 +43,7 @@ def find_column(input,token):
 
 states = (
     ('condition', 'exclusive'),
+    ('regex', 'exclusive'),
     ('actionkey', 'exclusive'),
     ('actionvalue', 'exclusive'),
     ('tagvalue', 'exclusive'),
@@ -71,7 +72,10 @@ tokens = (
     'SIGN',
     'NOT',
     'IDENTIFIER',
-    'REGEX',
+    'REGEX_START',
+
+    #Regex
+    'REGEX_BODY',
 
     #Actions
     'LCBRACE',
@@ -115,8 +119,7 @@ t_ANY_ignore  = ' \t'
 t_SUBJECT = r'\w+|\*'
 t_condition_SIGN = r'!~|=~|<>|<=|>=|!=|<|>|=|~='
 t_condition_NOT = r'\!'
-t_condition_IDENTIFIER = r'[^!<>=\[\]~]+'
-t_condition_REGEX = r'/\w+?/'
+t_condition_IDENTIFIER = r'[^/!<>=\[\]~]+'
 t_COMMA = r','
 t_actionkey_KEY = r'[\w-]+'
 t_actionkey_CLASS = r'\.\w+'
@@ -257,6 +260,16 @@ def t_LCBRACE(t):
 def t_LSQBRACE(t):
     r'\['
     t.lexer.push_state('condition')
+    return t
+
+def t_condition_REGEX_START(t):
+    r'/'
+    t.lexer.push_state('regex')
+    return t
+
+def t_regex_REGEX_BODY(t):
+    r'[^/]*/'
+    t.lexer.pop_state()
     return t
 
 def t_condition_RSQBRACE(t):

--- a/mapcss_parser/parse.py
+++ b/mapcss_parser/parse.py
@@ -142,8 +142,8 @@ def p_condition_check(p):
     p[0] = ast.ConditionCheck(p[1], p[2], p[3])
 
 def p_condition_regex(p):
-    'condition : IDENTIFIER SIGN REGEX'
-    p[0] = ast.ConditionRegex(p[1], p[2], p[3])
+    'condition : IDENTIFIER SIGN REGEX_START REGEX_BODY'
+    p[0] = ast.ConditionCheck(p[1], p[2], p[3] + p[4])
 
 def p_condition_set(p):
     'condition : IDENTIFIER'

--- a/tests/basic/selector/regex.pass_re
+++ b/tests/basic/selector/regex.pass_re
@@ -1,1 +1,1 @@
-\(+type == 'way'\)? && /^\(2|3\)0\$/.test\(tags\['maxspeed'\]\)+ {.*s_default\['z-index'\] = 1000[^}]*}.*presence_tags = \[[ \t]*\].*value_tags = \['maxspeed'\]
+if \(+type == 'way'\)? && /\^\(2|3\)0\$/\.test\(tags\['maxspeed'\]\)+ {.*s_default\['z-index'\] = 1000[^}]*}[^}]*if \(+type == 'way'\)? && /\^\[45\]0\$/\.test\(tags\['maxspeed'\]\)+ {.*s_default\['z-index'\] = 1001[^}]*}.*presence_tags = \[\].*value_tags = \['maxspeed'\]

--- a/tests/basic/selector/regex.tst
+++ b/tests/basic/selector/regex.tst
@@ -2,3 +2,7 @@ way[maxspeed=~/^(2|3)0$/]
 {
 	z-index: 1000;
 }
+way[maxspeed=~/^[45]0$/]
+{
+	z-index: 1001;
+}

--- a/tests/known_bugs/parse/issue24-square-regex.ill
+++ b/tests/known_bugs/parse/issue24-square-regex.ill
@@ -1,4 +1,0 @@
-canvas[foo=~/bla[0-9]/]
-{
-	default-lines: true;
-}


### PR DESCRIPTION
Until now the square brackets were taken as the opening brackets of selectors. Create a state for regular expressions to get a new matching scope. This also needs fixing of the p_condition_regex() function, which called an undefined class ConditionRegex. This was not hit until now because the rule never matched, until now regular expressions were matched as identifiers. From now on slashes are not allowed in identifiers anymore.

This fixes #24.