### PR TITLE
avoid duplicate checks on variable

### DIFF
--- a/mapcss_converter.py
+++ b/mapcss_converter.py
@@ -286,11 +286,9 @@ def eval_op_as_js(self, subpart):
     op = self.operation
     if op == '.':
         op = '+'
-
-    if op == 'eq':
+    elif op == 'eq':
         op = '=='
-
-    if op == 'ne':
+    elif op == 'ne':
         op = '!='
 
     return "%s %s %s" % (self.arg1.as_js(subpart), self.operation, self.arg2.as_js(subpart))


### PR DESCRIPTION
If any of these conditions match no other will. Use elif constructs to only use the minimum number of checks.