### PR TITLE
do not render labels that contain only whitespace

### DIFF
--- a/kothic/renderer/texticons.js
+++ b/kothic/renderer/texticons.js
@@ -62,14 +62,14 @@ Kothic.texticons = {
 			}
 		}
 
-		if (renderText) {
+		var text = String(style.text).trim();
+		if (renderText && text) {
 			Kothic.style.setStyles(ctx, {
 				lineWidth: style['text-halo-radius'] * 2,
 				font: Kothic.style.getFontString(style['font-family'], style['font-size'], style)
 			});
 
-			var text = String(style.text),
-					textWidth = ctx.measureText(text).width,
+			var textWidth = ctx.measureText(text).width,
 					letterWidth = textWidth / text.length,
 					collisionWidth = textWidth,
 					collisionHeight = letterWidth * 2.5,


### PR DESCRIPTION
This is not only faster, it also makes sure no other labels can collide with these invisible labels, so more labels will be shown at the end.