### PR TITLE
fix illegal character reporting in first line

### DIFF
--- a/mapcss_parser/lex.py
+++ b/mapcss_parser/lex.py
@@ -37,8 +37,6 @@ import ply.lex as lex
 # Basically taken from the PLY documentation
 def find_column(input,token):
 	last_cr = input.rfind('\n',0,token.lexpos)
-	if last_cr < 0:
-		last_cr = 0
 	return (token.lexpos - last_cr)
 
 states = (


### PR DESCRIPTION
Testcase: an illegal character at the first position of a line.

If this is the first line:

   Illegal character '(' at line 1 position 0

Otherwise:

   Illegal character '(' at line 2 position 1

Make this consistent so the position is always reported 1-based.