### PR TITLE
Add support for "@supports" statements

### DIFF
--- a/mapcss_converter.py
+++ b/mapcss_converter.py
@@ -386,6 +386,14 @@ def image_as_js(image):
         image['offset']
     )
 
+def supports_as_js(self):
+    tag_enable.append(self.value())
+    return ""
+
+def supports_end_as_js(supports):
+    tag_enable.pop()
+    return ""
+
 ast.MapCSS.as_js = mapcss_as_js
 ast.Rule.as_js = rule_as_js
 ast.Selector.as_js = selector_as_js
@@ -405,6 +413,8 @@ ast.EvalExpressionString.as_js = eval_string_as_js
 ast.EvalExpressionOperation.as_js = eval_op_as_js
 ast.EvalExpressionGroup.as_js = eval_group_as_js
 ast.EvalFunction.as_js = eval_function_as_js
+ast.Supports.as_js = supports_as_js
+ast.SupportsEnd.as_js = supports_end_as_js
 
 if __name__ == "__main__":
     from optparse import OptionParser

--- a/mapcss_parser/ast.py
+++ b/mapcss_parser/ast.py
@@ -30,6 +30,8 @@
 MapCSS data model. This is "as is" object representation of MapCSS file
 """
 
+import re
+
 def is_number(s):
 	try:
 		float(s)
@@ -234,3 +236,77 @@ class EvalFunction:
 
 	def __str__(self):
 		return "%s(%s)" % (self.function, ", ".join(map(str, self.arguments)))
+
+class Supports:
+	def __init__(self, conditions):
+		self.conditions = conditions
+
+	def __str__(self):
+		return "@supports"
+
+	def value(self):
+		return self.conditions.value()
+
+class SupportsAnd:
+	def __init__(self, condA, condB):
+		self.condA = condA
+		self.condB = condB
+
+	def __str__(self):
+		return "(%s) AND (%s)" % (self.condA, self.condB)
+
+	def value(self):
+		if not self.condA.value():
+			return False
+
+		return self.condB.value()
+
+class SupportsOr:
+	def __init__(self, condA, condB):
+		self.condA = condA
+		self.condB = condB
+
+	def __str__(self):
+		return "(%s) OR (%s)" % (self.condA, self.condB)
+
+	def value(self):
+		if self.condA.value():
+			return True
+
+		return self.condB.value()
+
+class SupportsNot:
+	def __init__(self, cond):
+		self.cond = cond
+
+	def __str__(self):
+		return "NOT (%s)" % self.cond
+
+	def value(self):
+		return not self.cond.value()
+
+class SupportsCondition:
+	def __init__(self, cond):
+		self.cond = cond
+
+	def __str__(self):
+		return "%s" % self.cond
+
+	def value(self):
+		return self.cond.value()
+
+class SupportsDecl:
+	def __init__(self, condition):
+		self.cond = condition
+
+	def __str__(self):
+		return "%s" % self.cond
+
+	def value(self):
+		if re.search(r'user-agent[ \t]*:[ \t]*node-tileserver', self.cond):
+			return True
+		return False
+
+class SupportsEnd:
+	def __str__(self):
+		return "}"

--- a/mapcss_parser/lex.py
+++ b/mapcss_parser/lex.py
@@ -51,6 +51,9 @@ states = (
 	('eval', 'exclusive'),
 	('mediasel', 'exclusive'),
 	('mediacontent', 'inclusive'),
+	('supportssel', 'exclusive'),
+	('supportsselparen', 'inclusive'),
+	('supportscontent', 'inclusive'),
 )
 
 tokens = (
@@ -111,6 +114,17 @@ tokens = (
 	'MFEATURE',
 	'MLCBRACE',
 	'MRCBRACE',
+
+	#@supports
+	'SUPPORTS',
+	'SUP_LCBRACE',
+	'SUP_RCBRACE',
+	'SUP_LPAREN',
+	'SUP_RPAREN',
+	'SUP_NOT',
+	'SUP_OR',
+	'SUP_AND',
+	'SUP_STATEMENT',
 )
 
 # Completely ignored characters
@@ -131,6 +145,10 @@ t_eval_NUMBER = r'\d+(\.\d+)?'
 t_eval_OPERATION = r'\+|-|\*|\/|==|<>|!=|<=|>=|>|<|eq|ne|\.'
 t_eval_FUNCTION = r'\w+'
 t_eval_COMMA = r','
+
+t_supportssel_SUP_NOT = '[Nn][Oo][Tt]'
+t_supportssel_SUP_OR = '[Oo][Rr]'
+t_supportssel_SUP_AND = '[Aa][Nn][Dd]'
 
 def t_ANY_CXXCOMMENT(t):
 	r'//[^\n]*'
@@ -311,6 +329,37 @@ def t_mediasel_MLCBRACE(t):
 	r'{'
 	t.lexer.pop_state()
 	t.lexer.push_state('mediacontent')
+	return t
+
+def t_SUPPORTS(t):
+	r'@supports'
+	t.lexer.push_state('supportssel')
+	return t
+
+def t_supportssel_SUP_LCBRACE(t):
+	r'{'
+	t.lexer.pop_state()
+	t.lexer.push_state('supportscontent')
+	return t
+
+def t_supportscontent_SUP_RCBRACE(t):
+	r'}'
+	t.lexer.pop_state()
+	return t
+
+def t_supportssel_SUP_LPAREN(t):
+	r'\('
+	t.lexer.push_state('supportsselparen')
+	return t
+
+def t_supportsselparen_SUP_RPAREN(t):
+	r'\)'
+	t.lexer.pop_state()
+	return t
+
+# this is incomplete, but should work for now
+def t_supportsselparen_SUP_STATEMENT(t):
+	r'[^(){}\n]+(\([^(){}]*\)\n)*[^(){}\n]*'
 	return t
 
 # Error handling rule

--- a/mapcss_parser/parse.py
+++ b/mapcss_parser/parse.py
@@ -52,6 +52,11 @@ def p_mapcss_media(p):
 	'css : media'
 	p[0] = ast.MapCSS()
 
+def p_mapcss_supports(p):
+	'css : supports'
+	p[0] = ast.MapCSS()
+	p[0].append_rule(p[1])
+
 def p_mapcss_multiple_rules(p):
 	'css : css rule'
 	p[0] = p[1]
@@ -65,6 +70,11 @@ def p_mapcss_multiple_imports(p):
 def p_mapcss_multiple_medias(p):
 	'css : css media'
 	p[0] = p[1]
+
+def p_mapcss_multiple_supports(p):
+	'css : css supports'
+	p[0] = p[1]
+	p[0].append_rule(p[2])
 
 def p_import_pseudoclass(p):
 	'import : IMPORT URL PSEUDOCLASS SEMICOLON'
@@ -236,5 +246,58 @@ def p_eval_function(p):
 # Media
 def p_media(p):
 	'media : MEDIA MLCBRACE'
+
+def p_supports_condition_neg(p):
+	'sup_condition : sup_negation'
+	p[0] = ast.SupportsCondition(p[1])
+
+def p_supports_condition_conj(p):
+	'sup_condition : sup_conjunction'
+	p[0] = ast.SupportsCondition(p[1])
+
+def p_supports_condition_disj(p):
+	'sup_condition : sup_disjunction'
+	p[0] = ast.SupportsCondition(p[1])
+
+def p_supports_condition_parens(p):
+	'sup_condition : sup_cond_parens'
+	p[0] = ast.SupportsCondition(p[1])
+
+def p_supports_negation(p):
+	'sup_negation : SUP_NOT sup_cond_parens'
+	p[0] = ast.SupportsNot(p[2])
+
+def p_supports_conjunction(p):
+	'sup_conjunction : sup_cond_parens SUP_AND sup_cond_parens'
+	p[0] = ast.SupportsAnd(p[1], p[3])
+
+def p_supports_multiple_conjunction(p):
+	'sup_conjunction : sup_conjunction SUP_AND sup_cond_parens'
+	p[0] = ast.SupportsAnd(p[1], p[3])
+
+def p_supports_disjunction(p):
+	'sup_disjunction : sup_cond_parens SUP_OR sup_cond_parens'
+	p[0] = ast.SupportsOr(p[1], p[3])
+
+def p_supports_multiple_disjunction(p):
+	'sup_disjunction : sup_disjunction SUP_OR sup_cond_parens'
+	p[0] = ast.SupportsOr(p[1], p[3])
+
+def p_supports_parens(p):
+	'sup_cond_parens : SUP_LPAREN sup_condition SUP_RPAREN'
+	p[0] = p[2]
+
+def p_support_decl_condition(p):
+	'sup_cond_parens : SUP_LPAREN SUP_STATEMENT SUP_RPAREN'
+	p[0] = ast.SupportsDecl(p[2])
+
+def p_supports(p):
+	'supports : SUPPORTS sup_condition SUP_LCBRACE'
+	p[0] = ast.Supports(p[2])
+
+def p_supports_end(p):
+	'css : css SUP_RCBRACE'
+	p[0] = p[1]
+	p[0].append_rule(ast.SupportsEnd())
 
 yacc.yacc(debug=0)

--- a/tests/known_bugs/supports/extra-paren.ill
+++ b/tests/known_bugs/supports/extra-paren.ill
@@ -1,0 +1,5 @@
+@supports (( z-index: 1 )) {
+	node {
+		z-index: 1;
+	}
+}

--- a/tests/supports/and.fail_re
+++ b/tests/supports/and.fail_re
@@ -1,0 +1,3 @@
+\(+type == 'way'\)+ {.*s_default\['z-index'\] = 2
+Illegal character
+Syntax error

--- a/tests/supports/and.pass_re
+++ b/tests/supports/and.pass_re
@@ -1,0 +1,1 @@
+\(+type == 'node'\)+ {.*s_default\['z-index'\] = 1[^}]*}.*presence_tags = \[[ \t]*\].*value_tags = \[[ \t]*\]

--- a/tests/supports/and.tst
+++ b/tests/supports/and.tst
@@ -1,0 +1,12 @@
+@supports ( user-agent: node-tileserver ) and
+          ( user-agent: other ) {
+	way {
+		z-index: 2;
+	}
+}
+@supports ( user-agent: node-tileserver ) AND
+          ( user-agent: node-tileserver ) {
+	node {
+		z-index: 1;
+	}
+}

--- a/tests/supports/decl.tst
+++ b/tests/supports/decl.tst
@@ -1,0 +1,5 @@
+@supports ( z-index: 1 ) {
+	node {
+		z-index: 1;
+	}
+}

--- a/tests/supports/decl_rule_after.fail_re
+++ b/tests/supports/decl_rule_after.fail_re
@@ -1,0 +1,1 @@
+s_default\['z-index'\] = 1

--- a/tests/supports/decl_rule_after.pass_re
+++ b/tests/supports/decl_rule_after.pass_re
@@ -1,0 +1,1 @@
+\(+type == 'way'\)+ {.*s_default\['z-index'\] = 2[^}]*}.*presence_tags = \[[ \t]*\].*value_tags = \[[ \t]*\]

--- a/tests/supports/decl_rule_after.tst
+++ b/tests/supports/decl_rule_after.tst
@@ -1,0 +1,9 @@
+@supports ( impossible : true ) {
+	node {
+		z-index: 1;
+	}
+}
+
+way {
+	z-index: 2;
+}

--- a/tests/supports/extra-paren-left.pass_re
+++ b/tests/supports/extra-paren-left.pass_re
@@ -1,0 +1,1 @@
+Illegal character

--- a/tests/supports/extra-paren-left.tst
+++ b/tests/supports/extra-paren-left.tst
@@ -1,0 +1,5 @@
+@supports (( z-index: 1 ) {
+	node {
+		z-index: 1;
+	}
+}

--- a/tests/supports/extra-paren-right.pass_re
+++ b/tests/supports/extra-paren-right.pass_re
@@ -1,0 +1,1 @@
+Illegal character

--- a/tests/supports/extra-paren-right.tst
+++ b/tests/supports/extra-paren-right.tst
@@ -1,0 +1,5 @@
+@supports ( z-index: 1 )) {
+	node {
+		z-index: 1;
+	}
+}

--- a/tests/supports/not.pass_re
+++ b/tests/supports/not.pass_re
@@ -1,0 +1,1 @@
+\(+type == 'node'\)+ {.*s_default\['z-index'\] = 1[^}]*}.*presence_tags = \[[ \t]*\].*value_tags = \[[ \t]*\]

--- a/tests/supports/not.tst
+++ b/tests/supports/not.tst
@@ -1,0 +1,5 @@
+@supports NOT ( user-agent: other ) {
+	node {
+		z-index: 1;
+	}
+}

--- a/tests/supports/or.pass_re
+++ b/tests/supports/or.pass_re
@@ -1,0 +1,1 @@
+\(+type == 'node'\)+ {.*s_default\['z-index'\] = 1[^}]*}.*presence_tags = \[[ \t]*\].*value_tags = \[[ \t]*\]

--- a/tests/supports/or.tst
+++ b/tests/supports/or.tst
@@ -1,0 +1,6 @@
+@supports ( user-agent: node-tileserver ) OR
+          ( user-agent: other ) {
+	node {
+		z-index: 1;
+	}
+}

--- a/tests/supports/user-agent-match.pass_re
+++ b/tests/supports/user-agent-match.pass_re
@@ -1,0 +1,1 @@
+\(+type == 'node'\)+ {.*s_default\['z-index'\] = 1[^}]*}.*presence_tags = \[[ \t]*\].*value_tags = \[[ \t]*\]

--- a/tests/supports/user-agent-match.tst
+++ b/tests/supports/user-agent-match.tst
@@ -1,0 +1,5 @@
+@supports ( user-agent: node-tileserver ) {
+	node {
+		z-index: 1;
+	}
+}

--- a/tests/supports/user-agent-no_match.tst
+++ b/tests/supports/user-agent-no_match.tst
@@ -1,0 +1,5 @@
+@supports ( user-agent : josm ) {
+	node {
+		z-index: 1;
+	}
+}


### PR DESCRIPTION
JOSM wants to phase out support for "@media", and use "@supports" instead. This parser is a bit more elaborate than the "@media" parser, and can also identify itself as "user-agent: node-tileserver".

This should allow merging [PR #451 in OpenRailwayMap](https://github.com/rurseekatze/OpenRailwayMap/pull/451).