### PR TITLE
Wrap labels

### DIFF
--- a/kothic/renderer/texticons.js
+++ b/kothic/renderer/texticons.js
@@ -69,14 +69,6 @@ Kothic.texticons = {
 				font: Kothic.style.getFontString(style['font-family'], style['font-size'], style)
 			});
 
-			var textWidth = ctx.measureText(text).width,
-					letterWidth = textWidth / text.length,
-					collisionWidth = textWidth,
-					collisionHeight = letterWidth * 2.5,
-					offsetX = style['text-offset-x'] || 0,
-					// TODO direcion of y-offset is reverse in JOSM
-					offsetY = style['text-offset'] || style['text-offset-y'] || 0;
-
 			var halo = (style.hasOwnProperty('text-halo-radius'));
 
 			Kothic.style.setStyles(ctx, {
@@ -95,6 +87,14 @@ Kothic.texticons = {
 				text = text.replace(/(^|\s)\S/g, function(ch) { return ch.toUpperCase(); });
 
 			if (feature.type === 'Polygon' || feature.type === 'Point') {
+				var textWidth = ctx.measureText(text).width,
+					letterWidth = textWidth / text.length,
+					collisionWidth = textWidth,
+					collisionHeight = letterWidth * 2.5,
+					offsetX = style['text-offset-x'] || 0,
+					// TODO direction of y-offset is reverse in JOSM
+					offsetY = style['text-offset'] || style['text-offset-y'] || 0;
+
 				if ((style['text-allow-overlap'] !== 'true') &&
 						collides.checkPointWH([point[0] + offsetX, point[1] + offsetY], collisionWidth, collisionHeight, feature.kothicId)) {
 					return;

--- a/kothic/renderer/texticons.js
+++ b/kothic/renderer/texticons.js
@@ -87,27 +87,73 @@ Kothic.texticons = {
 				text = text.replace(/(^|\s)\S/g, function(ch) { return ch.toUpperCase(); });
 
 			if (feature.type === 'Polygon' || feature.type === 'Point') {
-				var textWidth = ctx.measureText(text).width,
-					letterWidth = textWidth / text.length,
-					collisionWidth = textWidth,
-					collisionHeight = letterWidth * 2.5,
-					offsetX = style['text-offset-x'] || 0,
-					// TODO direction of y-offset is reverse in JOSM
-					offsetY = style['text-offset'] || style['text-offset-y'] || 0;
+				for (var i = 0; i < 5; i++) {
+					var rtext;	// the split label text
 
-				if ((style['text-allow-overlap'] !== 'true') &&
-						collides.checkPointWH([point[0] + offsetX, point[1] + offsetY], collisionWidth, collisionHeight, feature.kothicId)) {
-					return;
+					switch (i) {
+					case 0:
+						// if the text contains braces split there
+						rtext = text.replace(/ \(/g, '\n(').split('\n');
+						break;
+					case 1:
+						// if not, try splitting at slashes
+						rtext = text.replace(/\//g, '/\n').split('\n');
+						break;
+					case 2:
+						// try unmodified string
+						rtext = [ text ];
+						break;
+					case 3:
+						rtext = text.replace(/-/g, '-\n').split('\n');
+						break;
+					case 4:
+						rtext = text.split(' ');
+						break;
+					}
+					var s, rlines = rtext.length;
+					// only allow a single string when explicitely wanted
+					if (rlines === 1 && i !== 2)
+						continue;
+
+					var collisionWidth = 0,		// width of the longest substring
+						letterWidth = 0;	// mean width of a letter of the longest substring
+
+					for (s of rtext) {
+						var textWidth = ctx.measureText(s).width;
+						if (collisionWidth < textWidth) {
+							collisionWidth = textWidth;
+							letterWidth = textWidth / s.length;
+						}
+					}
+
+					var lheight = 1.3 * ctx.measureText('M').width,
+							collisionHeight = letterWidth * 0.3 + lheight * rlines,
+							offsetX = style['text-offset-x'] || 0,
+							// TODO direction of y-offset is reverse in JOSM
+							offsetY = style['text-offset'] || style['text-offset-y'] || 0;
+
+					if ((style['text-allow-overlap'] !== 'true') &&
+							collides.checkPointWH([point[0] + offsetX, point[1] + offsetY], collisionWidth, collisionHeight, feature.kothicId)) {
+						continue;
+					}
+
+					// now paint the texts
+					// iterate over all lines, the expression after offsetY is there to keep
+					// the center of the drawn text in the center of the collision rectangle
+					var l = 0;
+					if (halo) {
+						for (s of rtext)
+							ctx.strokeText(s, point[0] + offsetX, point[1] + offsetY + (l++ - (rlines - 1) / 2) * lheight);
+					}
+					l = 0;
+					for (s of rtext)
+						ctx.fillText(s, point[0] + offsetX, point[1] + offsetY + (l++ - (rlines - 1) / 2) * lheight);
+
+					var padding = style['kothicjs-min-distance'] || 20;
+					collides.addPointWH([point[0] + offsetX, point[1] + offsetY], collisionWidth, collisionHeight, padding, feature.kothicId);
+
+					break;
 				}
-
-				if (halo) {
-					ctx.strokeText(text, point[0] + offsetX, point[1] + offsetY);
-				}
-				ctx.fillText(text, point[0] + offsetX, point[1] + offsetY);
-
-				var padding = style['kothicjs-min-distance'] || 20;
-				collides.addPointWH([point[0] + offsetX, point[1] + offsetY], collisionWidth, collisionHeight, padding, feature.kothicId);
-
 			} else if (feature.type === 'LineString') {
 
 				var points = Kothic.geom.transformPoints(feature.coordinates, ws, hs);


### PR DESCRIPTION
This wraps the labels of polygons and points at different points, trying harder to paint them on the map. This greatly increases e.g. the number of stations names that can be shown on the map, as collisions with the tile borders are less likely to occur.