### PR TITLE
simplify filtering out empty layers

### DIFF
--- a/kothic/kothic.js
+++ b/kothic/kothic.js
@@ -186,10 +186,10 @@ var Kothic = {
 		layerIds = ['_bg'].concat(layerIds);
 
 		for (i = 0; i < layerIds.length; i++) {
-			// begin modified by rurseekatze
-			//queue = layersToRender[layerIds[i]];
-			queue = layersToRender[layerIds[i]] = layersToRender[layerIds[i]] || {};
-			// end modified by rurseekatze
+			queue = layersToRender[layerIds[i]];
+			if (!queue)
+				continue;
+
 			if (queue.polygons) {
 				for (j = 0, len = queue.polygons.length; j < len; j++) {
 					Kothic.polygon.render(ctx, queue.polygons[j], queue.polygons[j + 1], ws, hs, granularity);


### PR DESCRIPTION
Instead of creating an empty object and inserting it into the layersToRender array simply check if there was an object at all and stop doing any checks that must fail anyway.

The same change is now upstream in revision [285bd3d034af20b6c1b773e0a3a59ed436be273c](https://github.com/kothic/kothic-js/commit/285bd3d034af20b6c1b773e0a3a59ed436be273c).