### PR TITLE
fix rendering of polygons where one border goes from one tile boundary to another

### DIFF
--- a/kothic/renderer/path.js
+++ b/kothic/renderer/path.js
@@ -81,8 +81,39 @@ Kothic.path = (function () {
 		ctx.restore();
 	}
 
+	// check if the point is on the tile boundary
+	// returns bitmask of affected tile boundaries
 	function isTileBoundary(p, size) {
-		return p[0] === 0 || p[0] === size || p[1] === 0 || p[1] === size;
+		var r = 0;
+		if (p[0] === 0)
+			r |= 1;
+		else if (p[0] === size)
+			r |= 2;
+		if (p[1] === 0)
+			r |= 4;
+		else if (p[1] === size)
+			r |= 8;
+		return r;
+	}
+
+	/* check if 2 points are both on the same tile boundary
+	 *
+	 * If points of the object are on the same tile boundary it is assumed
+	 * that the object is cut here and would originally continue beyond the
+	 * tile borders.
+	 *
+	 * This does not catch the case where the object is indeed exactly
+	 * on the tile boundaries, but this case can't properly be detected here.
+	 */
+	function checkSameBoundary(p, q, size) {
+		var bp = isTileBoundary(p, size);
+		if (!bp)
+			return 0;
+		var bq = isTileBoundary(q, size);
+		if (!bq)
+			return 0;
+
+		return (bp & bq);
 	}
 
 	return function (ctx, feature, dashes, fill, ws, hs, granularity) {
@@ -161,8 +192,7 @@ Kothic.path = (function () {
 						screenPoint = Kothic.geom.transformPoint(point, ws, hs);
 
 						if (j === 0 || (!fill &&
-								isTileBoundary(point, granularity) &&
-								isTileBoundary(prevPoint, granularity))) {
+								checkSameBoundary(point, prevPoint, granularity))) {
 							moveTo(ctx, screenPoint, dashes);
 						} else if (fill || !dashes) {
 							ctx.lineTo(screenPoint[0], screenPoint[1]);


### PR DESCRIPTION
Think of a square that is exactly the same size as the tile, but rotated by 45 degrees. Now the object in this tile consists of 8 points, 2 of them on each tile boundary. No line should be drawn between each of those pairs, because those are in fact no outer borders of the square. But the other lines were not drawn either because it was only checked if the points were on tile boundaries, but not on which ones.

From now on lines between points on tile borders will be drawn if the points are on distinct borders.

This fixes the rendering at http://www.openrailwaymap.org/?lang=en&lat=47.31991&lon=16.5636&zoom=18: one can see that there is actually something drawn in that tile http://b.tiles.openrailwaymap.org/standard/18/143133/91861.png.