### PR TITLE
remove one pair of extra braces around conditions

### DIFF
--- a/mapcss_converter.py
+++ b/mapcss_converter.py
@@ -200,7 +200,7 @@ def selector_as_js(self):
         return 'false'
 
     if self.criteria:
-        return "(%s == %s && %s)" % (subject_property, wrap_key(self.subject), criteria)
+        return "%s == %s && %s" % (subject_property, wrap_key(self.subject), criteria)
     else:
         return "%s == %s" % (subject_property, wrap_key(self.subject))
 


### PR DESCRIPTION
Those were only inserted if additional criteria were present and not only the object type was matched. But since all criteria are a big and-expression anyway there is not need for parenthesis around that as the object type is combined with them with and, too.