### PR TITLE
fix dash artifacts if line is partly on tile border

### DIFF
--- a/kothic/renderer/path.js
+++ b/kothic/renderer/path.js
@@ -187,6 +187,8 @@ Kothic.path = (function () {
 							setDashPattern(screenPoint, dashes);
 						} else if (!fill && checkSameBoundary(point, prevPoint, granularity)) {
 							ctx.moveTo(screenPoint[0], screenPoint[1]);
+							dashPattern.x = screenPoint[0];
+							dashPattern.y = screenPoint[1];
 						} else if (fill || !dashes) {
 							ctx.lineTo(screenPoint[0], screenPoint[1]);
 						} else {


### PR DESCRIPTION
Dashes are drawn from the last point a line ended to the current point. If the line is partly on a tile border it is not drawn there, but the last dash point is not updated, so the next dashed line will not start at the point where the line leaves the border, but at the point where it entered the border. Casing is implemented in terms of dashing, so it is also affected by this.

This is usually only visible for swmall narrow gauge tracks, e.g. in theme parks, as they are often tagged as a single, closed way. When this crosses a tile border the problem becomes visible.