### PR TITLE
stop processing once an empty tile has been served

### DIFF
--- a/tile.js
+++ b/tile.js
@@ -170,6 +170,7 @@ Tile.prototype =
 						callback(err);
 					});
 				});
+				return;
 			}
 
 			self.debug('Created path. Saving vector tile at path: ' + file);


### PR DESCRIPTION
Would lead to crashes otherwise as the already deleted tile object is used to process the same tile again.