### PR TITLE
use multiple copies of the emptytile file as link targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 	{
 		"byline": "^4.2.1",
 		"canvas": "^1.2.2",
+		"fs.extra": "^1.3.2",
 		"graceful-fs": "^3.0.6",
 		"http-proxy": "^1.11.1",
 		"log4js": "^0.6.24",


### PR DESCRIPTION
This is to overcome the hard link limits of the filesystems.